### PR TITLE
Make VRM a hyperlink to VRM page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # BitsightMaturityModel
 Maturity Model Dashboard for [VRM](https://www.bitsight.com/vendor-risk-management)
+
+## Products
+- [VRM](VRM.md)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # BitsightMaturityModel
-Maturity Model Dashboard
+Maturity Model Dashboard for [VRM](https://www.bitsight.com/vendor-risk-management)

--- a/VRM.md
+++ b/VRM.md
@@ -1,0 +1,7 @@
+# Vendor Risk Management (VRM)
+
+Bitsight's Vendor Risk Management (VRM) solution helps organizations evaluate and continuously monitor the cybersecurity posture of their third-party ecosystem. Use this page to track VRM-specific maturity goals, documentation, and implementation notes for the dashboard.
+
+## Resources
+- [Product overview](https://www.bitsight.com/vendor-risk-management)
+- [Support center](https://help.bitsighttech.com/)


### PR DESCRIPTION
Add a hyperlink to 'VRM' in `README.md` to direct users to the Bitsight VRM product page.

---
<a href="https://cursor.com/background-agent?bcId=bc-af05b7a6-27c7-4a69-8fb8-9d1bdd037a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-af05b7a6-27c7-4a69-8fb8-9d1bdd037a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

